### PR TITLE
Quench error in modern compilers by removing manual traps

### DIFF
--- a/src/rnn.c
+++ b/src/rnn.c
@@ -102,7 +102,7 @@ void compute_dense(const DenseLayer *layer, float *output, const float *input)
       for (i=0;i<N;i++)
          output[i] = relu(output[i]);
    } else {
-     *(int*)0=0;
+     __builtin_unreachable();
    }
 }
 
@@ -148,7 +148,7 @@ void compute_gru(const GRULayer *gru, float *state, const float *input)
       if (gru->activation == ACTIVATION_SIGMOID) sum = sigmoid_approx(WEIGHTS_SCALE*sum);
       else if (gru->activation == ACTIVATION_TANH) sum = tansig_approx(WEIGHTS_SCALE*sum);
       else if (gru->activation == ACTIVATION_RELU) sum = relu(WEIGHTS_SCALE*sum);
-      else *(int*)0=0;
+      else __builtin_unreachable();
       h[i] = z[i]*state[i] + (1-z[i])*sum;
    }
    for (i=0;i<N;i++)


### PR DESCRIPTION
This style of inducing the compiler to produce a x86 trap isn't used anymore, because it's opaque in its meaning, and has been replaced with internals like `__builtin_trap` or `__builtin_unreachable`. Here I use the latter because I think it conveys the semantics better, to both the compiler and the reader.

The main reason of this pull request, of course, is that, at least with Clang (but possibly also GCC), the lines of code in question were producing fatal errors with the default build configuration, which included `-Werror`. A workaround is to add `-Wno-error=null-dereference`, but why sweep the issues under the rug and let them stack for our future selves when we can solve them right away? Those edits were pretty simple to make  :)

```
-----BEGIN PGP SIGNATURE-----
iQGzBAABCAAdFiEErLuenQucPUxdd2DaVrpxUP5g8OIFAmKceCUACgkQVrpxUP5g
8OItQwv+Np9BlJfWWO5h3icgKCgT8oTZv04qTIskTlPFg8QosBU4ZjJOP+vxX2xE
rZzweOlBeYZOnOxo4y1SedGJZXRvhJNueLecx24SHATckyOSPxkZtR855q4NQq2/
xFLedV6e3/nKFlOuDNGFcOKx+I8tQEEtPiAIrWcWa2l3iOHPga7QMtwJIHUIT1Ne
VXDWTDx34Q4FUvytDUkLsr37Q93lcB7xqgwCDzaHR4Dr9cuFLeu5/2wrAFg49v65
P7xXyRcOyV1RKD+ECxkYEoKBduOlj6hVrYJuaLP+JLnpy6MMmBCIaAH0RECZyyaD
IAzxcPmo6cRPXnAB+CwIdyyHw9MefGvWCdWgk5pqflBUmhrQU2/8X/n0uZ0ks6r/
GlC7EC+EF1d/oyuHFgF1iZ4KCK5cAMUQGrvV3J7teCV4T5BO5Q0eJs+9QVirdLQg
IezppscViEOoo+iLUK8fS4u+hCJLliDYS6o5ymgqYTbVdxiRAhVLfy4XWFDoC94X
kBnu4RLh
=aIvv
-----END PGP SIGNATURE-----
Detached signature of pull request message (Markdown source code minus signature block itself).
2022/06/05 6:35 AM at UTC-03.
```